### PR TITLE
Changes playback to use base64

### DIFF
--- a/lib/playback.js
+++ b/lib/playback.js
@@ -18,11 +18,12 @@ module.exports = function playback(options) {
         var host = req.host || req.headers.host,
             path = req.path || req.url;
 
-        if (req.method.match(/POST|PUT/) && req.body) {
-            path += ('__' + new Buffer(req.body).toString('base64'));
-        }
-
-        return  req.method + '_' + (host + path);
+        return [
+          req.method,
+          host,
+          path,
+          new Buffer(req.body || '').toString('base64')
+          ].join('_');
     };
 
     var allFiles = {};
@@ -49,7 +50,7 @@ module.exports = function playback(options) {
         debug('file is empty or does not exist. are you sure you configured ' + options.hostname + ' correctly?');
     }
     else {
-        debug('Searching in ' + Object.keys(testFixtures).join(', '));
+        debug('searching in ' + Object.keys(testFixtures).join(', '));
     }
 
     return function handlePlayback(req, res) {
@@ -60,7 +61,7 @@ module.exports = function playback(options) {
             var fixturesForReq = testFixtures[keyForFixture(req)];
             if (!(Array.isArray(fixturesForReq) && fixturesForReq.length > 0)) {
                 if (!options.strict) {
-                    warn('warning: ' + keyForFixture(req) + ' was served directly from proxy.');
+                    warn('warning: ' + keyForFixture(req) + ' was served directly from proxy. Found: ' + fixturesForReq);
                     proxy(req, options.protocol, handleProxy);
                 } else {
                     warn('strict mode refused playback of missing recording ' + keyForFixture(req));


### PR DESCRIPTION
- Changes recording to display `uuid` of what was picked to be served
- Fixes bug displaying undefined when a endpoint actually did zero runs thru the proxy
